### PR TITLE
Use JSON.dump over to_json

### DIFF
--- a/bin/shotty
+++ b/bin/shotty
@@ -339,8 +339,8 @@ module Shotty
     http         = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == "https"
 
-    http.post(uri.path, payload.to_json, headers).tap do |response|
-      log { "POST #{url} - #{payload.to_json}" }
+    http.post(uri.path, JSON.dump(payload), headers).tap do |response|
+      log { "POST #{url} - #{JSON.dump(payload)}" }
       log { "  --> #{response.body}" }
 
       return yield response


### PR DESCRIPTION
JSON is autoloaded, so `to_json` could fail if it wasn't loaded yet.