### PR TITLE
Add `--disable=rubyopt` to shebang

### DIFF
--- a/bin/shotty
+++ b/bin/shotty
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby --disable=gems
+#!/usr/bin/ruby --disable=gems --disable=rubyopt
 # Usage: shotty [COMMAND] [ARGS]
 #
 # COMMANDS


### PR DESCRIPTION
We don't need `RUBYOPT`, so skip it and lose a tiny bit of overhead.