### PR TITLE
Allow `shotty url` to accept Dropbox chrooted paths

### DIFF
--- a/bin/shotty
+++ b/bin/shotty
@@ -169,7 +169,8 @@ module Shotty
   #
   # Returns a String.
   def url(file, method: nil, retries: 0)
-    file = dropbox_resolve_file(file)
+    exists_locally = File.exist?(File.expand_path(file))
+    file           = dropbox_resolve_file(file)
 
     begin
       if method
@@ -185,7 +186,7 @@ module Shotty
         abort "Couldn't find URL for #{file}"
       end
     rescue APIError => e
-      if e.is_a?(NotFoundError) && dropbox_running? && (retries -= 1) > 0
+      if e.is_a?(NotFoundError) && exists_locally && dropbox_running? && (retries -= 1) > 0
         log { "Trying again after a quick nap" }
 
         sleep 2

--- a/bin/shotty
+++ b/bin/shotty
@@ -432,26 +432,9 @@ module Shotty
   #   ~/Dropbox/Hi.png          - /Hi.png
   #   ~/Dropbox/Apps/Foo/Hi.png - /Apps/Foo/Hi.png
   #
-  # Aborts if:
-  #   - the file does not exist
-  #   - the file is a directory
-  #   - the file is not under `~/Dropbox`
-  #
   # Returns a String.
   def dropbox_resolve_file(file)
-    file = File.expand_path(file)
-
-    abort "#{file} does not exist" unless File.exist? file
-
-    file = File.realpath(file)
-
-    abort "#{file} is a directory" if File.directory? file
-
-    regex = Regexp.escape(config["dropbox_root"])
-
-    abort "#{file} is not under #{config["dropbox_root"]}" unless file.match(regex)
-
-    file.sub(/\A#{regex}/, "")
+    File.expand_path(file).sub(/\A#{Regexp.escape(config["dropbox_root"])}/, "")
   end
 
   # Internal: Check if Dropbox.app is running.


### PR DESCRIPTION
The API takes files without the `~/Dropbox` prefix, eg:

`~/Dropbox/Shotty/foo.png` is known by the API as `/Shotty/foo.png`

This PR allows the `shotty url` command (and underlying `Shotty.url` method) to accept either form.

Also, retries on `Shotty.url` are skipped if the path does not exist locally. 