### PR TITLE
Fix HTTP payload to JSON, logging

### DIFF
--- a/bin/shotty
+++ b/bin/shotty
@@ -335,14 +335,22 @@ module Shotty
       "Content-Type"  => "application/json"
     }.merge(headers)
 
-    payload    ||= JSON.generate(payload) unless payload.is_a?(String)
+    unless payload.nil? || payload.is_a?(String)
+      payload = JSON.generate(payload)
+    end
+
     uri          = URI.parse(url)
     http         = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme == "https"
 
     http.post(uri.path, payload, headers).tap do |response|
-      log { "POST #{url} - #{payload}" }
-      log { "  --> #{response.body}" }
+      log { "POST #{url}" }
+
+      unless payload.nil? || payload.is_a?(String)
+        log { "  PAYLOAD  --> #{payload}" }
+      end
+
+      log { "  RESPONSE --> #{response.body}" }
 
       return yield response
     end


### PR DESCRIPTION
Relates to #34

Don't use `||=` here or payloads aren't converted to JSON properly.

Only log a payload if it was a Hash.