### PR TITLE
Let Shotty.last_screenshot return files up to 60s old

### DIFF
--- a/bin/shotty
+++ b/bin/shotty
@@ -550,7 +550,7 @@ module Shotty
       mtime = File.mtime(file)
     end
 
-    if file && ((Time.now - mtime) < 30)
+    if file && ((Time.now - mtime) < 60)
       file
     else
       abort "No screenshot found"


### PR DESCRIPTION
Sometimes with High Sierra the screenshot popup can cause a delay